### PR TITLE
Deals with folds

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -35,6 +35,10 @@ fu! s:lastplace()
 				execute "normal! \G'\"\<c-e>"
 			endif
 		endif
+		if foldclosed(".")!=-1
+			"if we're in a fold, make the current line visible
+			execute "normal! zA"
+		endif
 	endif
 endf
 


### PR DESCRIPTION
If the current line is in a fold, open recusrively.
This is to match the `'"` behaviour.
