### PR TITLE
Improve fold behaviour

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -37,7 +37,7 @@ fu! s:lastplace()
 		endif
 		if foldclosed(".") != -1
 			"if we're in a fold, make the current line visible
-			execute "normal! zA"
+			execute "normal! zv"
 		endif
 	endif
 endf


### PR DESCRIPTION
Open just enough folds to view the cursor line.

Sorry for making a Pull Request for such silly change, I should have noticed that when a file has many folds, `zA` opens a ton of stuff, makes folds almost redundant.
