### PR TITLE
Fix files with Modelines

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -44,5 +44,5 @@ endf
 
 augroup lastplace_plugin
 	autocmd!
-	autocmd BufReadPost * call s:lastplace()
+	autocmd BufWinEnter * call s:lastplace()
 augroup END


### PR DESCRIPTION
It's me again.

This changes the event so that it happens after the modeline is set, to fix stuff like `foldmethod` set in the modeline leads to the current fold being open for a split-second, and then immediately closed.
This also has a side-effect of triggering when a hidden buffer is shown for the first time. I consider this a feature.

I think it's OK to run on both the old and new event, just a little redundant. 
