### PR TITLE
Fix crash when quickfix changes

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -23,6 +23,12 @@ if !exists('g:lastplace_open_folds')
 endif
 
 fu! s:lastplace()
+   	" lastplace is redundant for quickfix windows
+   	" and can also cause crashes when quickfix size changes
+   	if &buftype == "quickfix"
+		return
+   	endif
+
 	if index(split(g:lastplace_ignore, ","), &filetype) == -1 
 		if line("'\"") > 0 && line("'\"") <= line("$")
 			"if the last edit position is set and is less than the


### PR DESCRIPTION
plugins might change the amount of items at the quickfix window,
which causes neovim to crash: `floating point exception`.

lastplace is redundant for quickfix window -> this commit causes
lastplace to ignore quickfix windows.