### PR TITLE
Add note about disabling pre-existing last-edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ You can also use [pathogen.vim](https://github.com/tpope/vim-pathogen) or other 
     cd ~/.vim/bundle
     git clone git://github.com/farmergreg/vim-lastplace.git
 
+Depending on which Vim package you're using, your Vim may be preconfigured with
+last-edit-position logic.  If so, you may want to disable that in favor of
+vim-lastplace. For example, for Vim as packaged with Git for Windows, you can edit
+`C:\Program Files\Git\etc\vimrc` and comment out the "Remember positions in files"
+`autocmd BufReadPost *` block.
 
 ## Configuration
 You can configure what file types to ignore by setting

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ You can also use [pathogen.vim](https://github.com/tpope/vim-pathogen) or other 
     cd ~/.vim/bundle
     git clone git://github.com/farmergreg/vim-lastplace.git
 
-Depending on which Vim package you're using, your Vim may be preconfigured with
-last-edit-position logic.  If so, you may want to disable that in favor of
-vim-lastplace. For example, for Vim as packaged with Git for Windows, you can edit
+Depending on which Vim package you're using, Vim may be preconfigured with
+last-edit-position logic that doesn't work quite as well as vim-lastplace.
+If so, you may want to disable that in favor of vim-lastplace. For example,
+for Vim as packaged with Git for Windows, you can edit
 `C:\Program Files\Git\etc\vimrc` and comment out the "Remember positions in files"
 `autocmd BufReadPost *` block.
 


### PR DESCRIPTION
One of the Vim installations that I use already had last-edit functionality, and it triggered on Git commit messages, so I thought that something was wrong with vim-lastplace. It took me a while to track down where it was coming from. This paragraph may save others time if they're in a similar situation. If you'd rather not include it (because it's too much detail or is out of scope for vim-lastplace's documentation), then that's fine too.