### PR TITLE
Recenter screen when opening fold

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -69,8 +69,8 @@ fu! s:lastplace()
 		endif
 	endif
 	if foldclosed(".") != -1 && g:lastplace_open_folds
-		"if we're in a fold, make the current line visible
-		execute "normal! zv"
+		"if we're in a fold, make the current line visible and recenter screen
+		execute "normal! zvzz"
 	endif
 endf
 


### PR DESCRIPTION
When last place is inside fold, it's opened with "zv". However, after opening a fold cursor location is broken and is not more at the middle of the screen. So use "zvzz" instead of just "zv" to recenter screen.