### PR TITLE
Fix window split position on Neovim

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -76,5 +76,5 @@ endf
 
 augroup lastplace_plugin
 	autocmd!
-	autocmd BufWinEnter * call s:lastplace()
+	autocmd BufRead * call s:lastplace()
 augroup END


### PR DESCRIPTION
As reported in #28, there is a problem when switching between buffers in
split windows. This is a potential fix/workaround as proposed by
@natecraddock.

Patch is from this comment:

https://github.com/farmergreg/vim-lastplace/issues/28#issuecomment-1047085642