### PR TITLE
Restore column when near eof

### DIFF
--- a/plugin/vim-lastplace.vim
+++ b/plugin/vim-lastplace.vim
@@ -67,7 +67,7 @@ fu! s:lastplace_jump()"{{{
             "otherwise, show as much context as we can by jumping to the end of the file and then to the mark.
             "if we pressed zz here, there would be blank lines at the bottom of the screen.
             "we intentionally leave the last line blank by pressing <c-e> so the user can see that they are near the end of the file.
-            execute "keepjumps normal! \G'\"\<c-e>"
+            execute "keepjumps normal! \G`\"\<c-e>"
         endif
     endif
 endf"}}}


### PR DESCRIPTION
Hi! Thanks for this very useful plugin :+1: 

The only thing that bothered me a bit is that it uses quote instead of backtick when we're near the end of the file, which means it jumps to first non-blank character (so not restoring the column position). Seems like it was like that right from it's introduction in 2015 (https://github.com/farmergreg/vim-lastplace/commit/945cc1a062d847d01e10f09c0e8480c371706524), but I'm not sure if it's actually intended to behave like that for some reason.